### PR TITLE
ci: fix needs for create-release and pass tag name via env

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,26 +11,6 @@ jobs:
   test:
     uses: ./.github/workflows/main.yaml
 
-  create-release:
-    runs-on: ubuntu-latest
-    needs: [publish-maven-central, publish-github-packages]
-    permissions:
-      contents: write
-      packages: write # publish a new github release
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
-
-      - name: Create Release
-        uses: Roang-zero1/github-create-release-action@57eb9bdce7a964e48788b9e78b5ac766cb684803 # v3.0.1
-        with:
-          version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
-          changelog_file: CHANGELOG.md
-          create_draft: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish:
     needs: test
     runs-on: ubuntu-latest
@@ -64,4 +44,25 @@ jobs:
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "${{ env.TAG_NAME }}" ./build/distributions/*
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+      packages: write # publish a new github release
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Create Release
+        uses: Roang-zero1/github-create-release-action@57eb9bdce7a964e48788b9e78b5ac766cb684803 # v3.0.1
+        with:
+          version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
+          changelog_file: CHANGELOG.md
+          create_draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Just needed to rename the needs field to publish, restructured also so the workflow reads like how it runs.

Also moving to pass via env makes it safer to read from context to avoid injection attacks.


## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
