### PR TITLE
build: run lexer generation before parser generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,6 +86,7 @@ tasks {
         pathToParser.set("dev/openfga/intellijplugin/parsing/OpenFGAParser.java")
         pathToPsiRoot.set("dev/openfga/intellijplugin/psi")
         purgeOldFiles.set(true)
+        dependsOn(generateLexer) // The lexer must be generated before parser otherwise we get build errors
     }
 
     test {


### PR DESCRIPTION
## Description

We've been seeing intermittent failures with errors like below, after some investigation it became apparent that every instance of this error occurred when `generateParser` ran before `generateLexer`. So force the `generateLexer` task to run first using `dependsOn`

```
> Task :compileJava FAILED
/Users/ewan/dev/git/openfga/intellij-plugin/src/main/java/dev/openfga/intellijplugin/parsing/OpenFGAParserDefinition.java:50: error: cannot find symbol
        return new OpenFGAParser();
                   ^
  symbol:   class OpenFGAParser
  location: class OpenFGAParserDefinition
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
