### PR TITLE
refactor: replace deprecated API usage

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
           - pycharmPY:2024.3
           - riderRD:2024.3
           - webstorm:2024.3
-          - ideaIC:LATEST-EAP-SNAPSHOT
+          # - ideaIC:LATEST-EAP-SNAPSHOT - Removed from testing as no YAML plugin exists yet
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("243.*")
+        untilBuild.set("251.*")
     }
 
     signPlugin {

--- a/src/main/java/dev/openfga/intellijplugin/OpenFGATemplateContext.java
+++ b/src/main/java/dev/openfga/intellijplugin/OpenFGATemplateContext.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class OpenFGATemplateContext extends TemplateContextType {
     protected OpenFGATemplateContext() {
-        super("OPENFGA_CONTEXT", "OpenFGA authorization model DSL");
+        super("OpenFGA authorization model DSL");
     }
 
     @Override

--- a/src/main/java/dev/openfga/intellijplugin/cli/tasks/DslToJsonTask.java
+++ b/src/main/java/dev/openfga/intellijplugin/cli/tasks/DslToJsonTask.java
@@ -79,7 +79,7 @@ public class DslToJsonTask extends Task.Backgroundable implements CliProcessTask
     public Void onSuccess(File stdOutFile, File stdErrFile) throws IOException, CliTaskException {
         Files.copy(stdOutFile.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING);
         ApplicationManager.getApplication()
-                .invokeLater(() -> show(new GeneratedFile(dslFile.getProject(), targetPath)), ModalityState.NON_MODAL);
+                .invokeLater(() -> show(new GeneratedFile(dslFile.getProject(), targetPath)), ModalityState.nonModal());
         return null;
     }
 

--- a/src/main/java/dev/openfga/intellijplugin/settings/OpenFGASettingsComponent.java
+++ b/src/main/java/dev/openfga/intellijplugin/settings/OpenFGASettingsComponent.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.ui.ComponentValidator;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.ui.DocumentAdapter;
@@ -46,11 +47,9 @@ public class OpenFGASettingsComponent {
                 .getPanel();
         clearCliPathField.addActionListener(evt -> cliPathField.setText(""));
         cliPathField.setEditable(false);
+
         cliPathField.addBrowseFolderListener(
-                "Select",
-                "Select OpenFGA cli path",
-                null,
-                new FileChooserDescriptor(true, false, false, false, false, false));
+                new TextBrowseFolderListener(new FileChooserDescriptor(true, false, false, false, false, false)));
 
         installValidator(cliPathField, this::validateCliPath);
         cliPathField.getTextField().getDocument().addDocumentListener(new DocumentAdapter() {


### PR DESCRIPTION
## Description

Bumps the `untilBuild` to support the upcoming 2025 versions, and replaces some deprecated API usage.

Manually tested the live templates and DSL->JSON transform that are where we used deprecated APIs and all is still functional.

## References

Closes #73
Closes #22

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

