### PR TITLE
release: v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.1.5
+
+### [0.1.5](https://github.com/openfga/intellij-plugin/compare/v0.1.4...v0.1.5) (2025-03-03)
+
+Added
+- add support for 2025.* based IDEs ([#80](https://github.com/openfga/intellij-plugin/pull/80))
+
 ## v0.1.4
 
 ### [0.1.4](https://github.com/openfga/intellij-plugin/compare/v0.1.3...v0.1.4) (2024-12-02)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "dev.openfga.intellijplugin"
-version = "0.1.4"
+version = "0.1.5"
 sourceSets["main"].java.srcDirs("src/main/java", "src/generated/java")
 
 repositories {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,7 +3,6 @@
 ## Bump version number
 
 - Update the `version` number in `build.gradle.kts`
-- Update the `pluginVersion` number in `gradle.properties`
 
 ## Update the CHANGELOG
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,3 @@ kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
-
-pluginGroup=dev.openfga.intellijplugin
-pluginName=OpenFgaIntellijPlugin
-pluginVersion=0.1.4

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,7 +20,7 @@
     <change-notes><![CDATA[
     <h2>New Features</h2>
     <ul>
-        <li>add support for IntelliJ 2024.3.* based IDEs</li>
+        <li>add support for 2025.* based IDEs</li>
     </ul>
     ]]></change-notes>
 


### PR DESCRIPTION
## Description

```
### [0.1.5](https://github.com/openfga/intellij-plugin/compare/v0.1.4...v0.1.5) (2025-03-03)

Added
- add support for 2025.* based IDEs ([#80](https://github.com/openfga/intellij-plugin/pull/80))
```

Also, removes the plugin values set in `gradle.properties`, these are not referenced from anywhere and are set in the `build.gradle.kts` file already (these are the values used to generated the plugin data) so are redundant. I tested building locally and everything works as expected

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

