### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,8 @@
 name: Pull Request build and test
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/intellij-plugin/security/code-scanning/6](https://github.com/openfga/intellij-plugin/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/main.yaml`. This block should be placed at the root level (above `jobs:`) to apply to all jobs in the workflow, unless a job needs more specific permissions. The minimal required permission for these jobs is likely `contents: read`, as they only check out code, build, test, and upload/download artifacts, but do not modify repository contents or interact with issues or pull requests. If any job later requires additional permissions, those can be added at the job level. The change involves inserting the following block after the workflow `name` and before `env` or `jobs`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
