### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,8 @@ jobs:
   publish:
     needs: [test, create-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/intellij-plugin/security/code-scanning/5](https://github.com/openfga/intellij-plugin/security/code-scanning/5)

To fix the problem, add a `permissions` block to the `publish` job in `.github/workflows/publish.yaml`. This block should grant only the minimal permissions required for the job to function. Since the `publish` job uploads release assets and edits releases using the `gh` CLI, it needs `contents: write` permission. If you want to be even more restrictive, you could test with `contents: write` only, as this is required for uploading release assets and editing releases. The `publish` job does not appear to need any other permissions. The change should be made by adding the following under the `publish:` job definition (at the same indentation level as `runs-on`):

```yaml
permissions:
  contents: write
```

No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
