### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,4 +1,6 @@
 name: FOSSA
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/intellij-plugin/security/code-scanning/3](https://github.com/openfga/intellij-plugin/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will ensure that all jobs in the workflow run with only read access to repository contents, unless a job explicitly overrides this. No changes to the jobs or steps are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
