### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/main.yaml
 
   # First create the release so that we have somewhere to upload the distribution zips to


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/intellij-plugin/security/code-scanning/2](https://github.com/openfga/intellij-plugin/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the `test` job in `.github/workflows/publish.yaml`. This block should specify the minimal permissions required for the job. If the job does not need to write to the repository, the safest default is `contents: read`. This change should be made directly under the `test:` job definition, before the `uses:` line. No additional imports or definitions are needed, as this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
