### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/intellij-plugin/security/code-scanning/1](https://github.com/openfga/intellij-plugin/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job to restrict the `GITHUB_TOKEN` to the least privilege required. In this case, the Semgrep job only needs to read repository contents, so set `permissions: contents: read` at the job level (under `semgrep:`). This change should be made directly under the job definition (after `name: Scan` and before `runs-on:`) in `.github/workflows/semgrep.yaml`. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
