### PR TITLE
fix: downgrade target to Java 17 as required by build 241 & below

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,6 @@ on:
 env:
   PLUGIN_ARTIFACT_NAME: 'openfga_intellij_plugin'
   DIST_FOLDER: 'build/distributions'
-  JAVA_VERSION: '17'
 
 jobs:
   build:
@@ -24,6 +23,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Read Java version from gradle.properties
+        run: |
+          JAVA_VERSION=$(grep '^javaVersion=' gradle.properties | cut -d'=' -f2)
+          if ! [[ "$JAVA_VERSION" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid Java version: $JAVA_VERSION"
+            exit 1
+          fi
+          echo "JAVA_VERSION=$JAVA_VERSION" >> "$GITHUB_ENV"
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -60,6 +68,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Read Java version from gradle.properties
+        run: |
+          JAVA_VERSION=$(grep '^javaVersion=' gradle.properties | cut -d'=' -f2)
+          if ! [[ "$JAVA_VERSION" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid Java version: $JAVA_VERSION"
+            exit 1
+          fi
+          echo "JAVA_VERSION=$JAVA_VERSION" >> "$GITHUB_ENV"
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ on:
 env:
   PLUGIN_ARTIFACT_NAME: 'openfga_intellij_plugin'
   DIST_FOLDER: 'build/distributions'
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '17'
 
 jobs:
   build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+env:
+  JAVA_VERSION: '17'
+
 jobs:
   test:
     permissions:
@@ -46,7 +49,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: 21
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
-env:
-  JAVA_VERSION: '17'
-
 jobs:
   test:
     permissions:
@@ -45,6 +42,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Read Java version from gradle.properties
+        run: |
+          JAVA_VERSION=$(grep '^javaVersion=' gradle.properties | cut -d'=' -f2)
+          if ! [[ "$JAVA_VERSION" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid Java version: $JAVA_VERSION"
+            exit 1
+          fi
+          echo "JAVA_VERSION=$JAVA_VERSION" >> "$GITHUB_ENV"
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,2 @@
 [tools]
-java = "21"
+java = "17"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,14 +83,14 @@ spotless {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_21
+    compilerOptions.jvmTarget = JvmTarget.JVM_17
     dependsOn("generateLexer", "generateParser")
 }
 
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
-    sourceCompatibility = "21"
-    targetCompatibility = "21"
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
     dependsOn("generateLexer", "generateParser")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ spotless {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_17
+    compilerOptions.jvmTarget = JvmTarget.JVM_21
     dependsOn("generateLexer", "generateParser")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,15 +82,17 @@ spotless {
     }
 }
 
+val javaVersion: String by project
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_17
+    compilerOptions.jvmTarget = JvmTarget.fromTarget(javaVersion)
     dependsOn("generateLexer", "generateParser")
 }
 
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
     dependsOn("generateLexer", "generateParser")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,11 @@ org.gradle.configuration-cache=true
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
 
+# JVM target version for compilation
+# Make sure it is compatible with the minimum supported version of IntelliJ Platform (17 for 2024.1+)
+# Source: https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#platformVersions
+javaVersion=17
+
 # Plugin compatibility
 plugin.sinceBuild=233
 plugin.untilBuild=261.*


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

Source: https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#platformVersions

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Make the Java toolchain version configurable from project settings (default set to 17).
  * CI and publishing workflows now read and validate that configured Java version and use it when setting up Java.
  * Kotlin and Java compilation targets are parameterized to follow the configured Java version rather than a hard-coded value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->