### PR TITLE
chore: upgrade gradle/actions setup-gradle to v6.1.0 with basic cache provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "gradle/actions"
+        versions: [">= 6.0.0, < 6.1.0"]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,9 +59,11 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
           gradle-home-cache-cleanup: true
+          # Use the basic cache provider to avoid issues with VPN-restricted environments
+          cache-provider: basic
 
       # Publish the plugin to JetBrains Marketplace
       - name: Publish Plugin


### PR DESCRIPTION
Upgrades gradle/actions/setup-gradle to v6.1.0 across all workflow jobs and switches to the open-source basic cache provider, avoiding reliance on the Gradle Build Scan service for caching.

Also narrows the dependabot ignore range from >= 6.0.0, < 7.0.0 to >= 6.0.0, < 6.1.0 so future v6.x patch releases are picked up automatically.

Mirrors the change applied in https://github.com/openfga/java-sdk/pull/318.