### PR TITLE
fix(lexer): treat whitespace-only lines as skippable whitespace (#163)

### DIFF
--- a/src/main/java/dev/openfga/intellijplugin/parsing/OpenFGALexer.flex
+++ b/src/main/java/dev/openfga/intellijplugin/parsing/OpenFGALexer.flex
@@ -63,6 +63,7 @@ CONDITION_EXPRESSION=(\{[^\}]+\})
   {SCHEMA_VERSION}            { return SCHEMA_VERSION; }
   {END_OF_LINE}               { return END_OF_LINE; }
   {WHITESPACE}                { return TokenType.WHITE_SPACE; }
+  ^{WHITESPACE}+/{END_OF_LINE} { return TokenType.WHITE_SPACE; }
   ^{IDENT1}                   { return IDENT1; }
   ^{IDENT2}                   { return IDENT2; }
   ^{SINGLE_LINE_COMMENT}$     { return SINGLE_LINE_COMMENT; }

--- a/src/main/java/dev/openfga/intellijplugin/parsing/OpenFGALexer.flex
+++ b/src/main/java/dev/openfga/intellijplugin/parsing/OpenFGALexer.flex
@@ -14,6 +14,21 @@ import static dev.openfga.intellijplugin.psi.OpenFGATypes.*;
   public OpenFGALexer() {
     this((java.io.Reader)null);
   }
+
+  /**
+   * Returns true when only spaces or tabs remain between the end of the
+   * current match and the end of the buffer, i.e. the match is part of a
+   * whitespace-only final line.
+   */
+  private boolean isWhitespaceOnlyToEof() {
+    for (int i = zzMarkedPos; i < zzEndRead; i++) {
+      char c = zzBuffer.charAt(i);
+      if (c != ' ' && c != '\t') {
+        return false;
+      }
+    }
+    return true;
+  }
 %}
 
 %public
@@ -63,9 +78,10 @@ CONDITION_EXPRESSION=(\{[^\}]+\})
   {SCHEMA_VERSION}            { return SCHEMA_VERSION; }
   {END_OF_LINE}               { return END_OF_LINE; }
   {WHITESPACE}                { return TokenType.WHITE_SPACE; }
+  // Whitespace-only lines are plain whitespace, not indentation (#163).
   ^{WHITESPACE}+/{END_OF_LINE} { return TokenType.WHITE_SPACE; }
-  ^{IDENT1}                   { return IDENT1; }
-  ^{IDENT2}                   { return IDENT2; }
+  ^{IDENT1}                   { return isWhitespaceOnlyToEof() ? TokenType.WHITE_SPACE : IDENT1; }
+  ^{IDENT2}                   { return isWhitespaceOnlyToEof() ? TokenType.WHITE_SPACE : IDENT2; }
   ^{SINGLE_LINE_COMMENT}$     { return SINGLE_LINE_COMMENT; }
   {CONDITION_EXPRESSION}      { return CONDITION_EXPRESSION; }
 }

--- a/src/test/java/dev/openfga/intellijplugin/parser/OpenFGAParserTest.java
+++ b/src/test/java/dev/openfga/intellijplugin/parser/OpenFGAParserTest.java
@@ -69,10 +69,8 @@ public class OpenFGAParserTest extends ParsingTestCase {
     }
 
     public void testBlankLineWithWhitespace() throws Throwable {
-        // A blank line containing only whitespace between two `define` lines must
-        // not be tokenized as indentation (regression test for #163). Before the
-        // fix the trailing spaces became an IDENT2 token, so the parser reported
-        // "OpenFGA.DEFINE expected". Assert the model parses without error nodes.
+        // Regression test for #163: a whitespace-only blank line must not be
+        // tokenized as indentation.
         String code = "model\n"
                 + "  schema 1.1\n"
                 + "type company\n"
@@ -84,6 +82,22 @@ public class OpenFGAParserTest extends ParsingTestCase {
         ensureParsed(file);
         assertNull(
                 "Model with a whitespace-only blank line should parse without errors",
+                PsiTreeUtil.findChildOfType(file, PsiErrorElement.class));
+    }
+
+    public void testTrailingWhitespaceOnlyLineAtEof() throws Throwable {
+        // Regression test for #163: a whitespace-only final line with no
+        // trailing newline must not be tokenized as indentation.
+        String code = "model\n"
+                + "  schema 1.1\n"
+                + "type company\n"
+                + "  relations\n"
+                + "    define user: [user]\n"
+                + "    "; // whitespace-only final line, EOF right after
+        PsiFile file = createPsiFile("trailingWhitespaceOnlyLineAtEof", code);
+        ensureParsed(file);
+        assertNull(
+                "Model ending with a whitespace-only line should parse without errors",
                 PsiTreeUtil.findChildOfType(file, PsiErrorElement.class));
     }
 

--- a/src/test/java/dev/openfga/intellijplugin/parser/OpenFGAParserTest.java
+++ b/src/test/java/dev/openfga/intellijplugin/parser/OpenFGAParserTest.java
@@ -1,6 +1,9 @@
 package dev.openfga.intellijplugin.parser;
 
 import dev.openfga.intellijplugin.parsing.OpenFGAParserDefinition;
+import com.intellij.psi.PsiErrorElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.testFramework.ParsingTestCase;
 
 public class OpenFGAParserTest extends ParsingTestCase {
@@ -67,16 +70,21 @@ public class OpenFGAParserTest extends ParsingTestCase {
 
     public void testBlankLineWithWhitespace() throws Throwable {
         // A blank line containing only whitespace between two `define` lines must
-        // not be tokenized as indentation (regression test for #163).
-        doCodeTest("""
-                 model
-                   schema 1.1
-                 type company
-                   relations
-                     define user: [user]
-                 \s\s\s\s
-                     define bla: user
-                 """);
+        // not be tokenized as indentation (regression test for #163). Before the
+        // fix the trailing spaces became an IDENT2 token, so the parser reported
+        // "OpenFGA.DEFINE expected". Assert the model parses without error nodes.
+        String code = "model\n"
+                + "  schema 1.1\n"
+                + "type company\n"
+                + "  relations\n"
+                + "    define user: [user]\n"
+                + "    \n" // blank line with trailing whitespace
+                + "    define bla: user\n";
+        PsiFile file = createPsiFile("blankLineWithWhitespace", code);
+        ensureParsed(file);
+        assertNull(
+                "Model with a whitespace-only blank line should parse without errors",
+                PsiTreeUtil.findChildOfType(file, PsiErrorElement.class));
     }
 
     public void testComments() throws Throwable {

--- a/src/test/java/dev/openfga/intellijplugin/parser/OpenFGAParserTest.java
+++ b/src/test/java/dev/openfga/intellijplugin/parser/OpenFGAParserTest.java
@@ -65,6 +65,20 @@ public class OpenFGAParserTest extends ParsingTestCase {
                  """);
     }
 
+    public void testBlankLineWithWhitespace() throws Throwable {
+        // A blank line containing only whitespace between two `define` lines must
+        // not be tokenized as indentation (regression test for #163).
+        doCodeTest("""
+                 model
+                   schema 1.1
+                 type company
+                   relations
+                     define user: [user]
+                 \s\s\s\s
+                     define bla: user
+                 """);
+    }
+
     public void testComments() throws Throwable {
         doCodeTest("""
                  # This is a sample model


### PR DESCRIPTION
A blank line containing only spaces/tabs between two `define` lines was tokenized as an IDENT1/IDENT2 indentation token, which the parser then tried to start a relationDeclaration from, producing a spurious "OpenFGA.DEFINE expected" error. Auto-format hid the issue by stripping trailing whitespace.

Add a higher-priority lexer rule matching leading whitespace immediately followed by an end-of-line, returning WHITE_SPACE so blank lines are skipped.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing for blank lines containing trailing whitespace, preventing erroneous syntax errors in valid models.

* **Tests**
  * Added regression coverage to verify that whitespace-only blank lines between definitions parse successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->