### PR TITLE
chore(ci/publish): generate plugin change-notes from CHANGELOG.md

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: Build the plugin using Gradle
         run: ./gradlew check buildPlugin
 
+      - name: Verify change-notes are generated from CHANGELOG.md
+        run: make check-change-notes
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Helpers for the plugin change-notes, which are generated at build time from
+# CHANGELOG.md (see changeNotesFromChangelog in build.gradle.kts).
+
+GRADLE ?= ./gradlew
+PATCHED_XML = $(shell find build -name plugin.xml -path '*patch*' 2>/dev/null | head -n1)
+
+.PHONY: change-notes print-change-notes check-change-notes clean-change-notes
+
+## change-notes: patch plugin.xml so build/ contains the generated notes
+change-notes:
+	$(GRADLE) patchPluginXml
+
+## print-change-notes: generate, then print the <change-notes> block
+print-change-notes: change-notes
+	@xml='$(PATCHED_XML)'; \
+	if [ -z "$$xml" ]; then \
+		echo "could not find a patched plugin.xml under build/" >&2; \
+		exit 1; \
+	fi; \
+	awk '/<change-notes>/{f=1} f{print} /<\/change-notes>/{exit}' "$$xml"
+
+## check-change-notes: fail if the generated notes are empty or the fallback
+check-change-notes: change-notes
+	@xml='$(PATCHED_XML)'; \
+	if [ -z "$$xml" ]; then \
+		echo "could not find a patched plugin.xml under build/" >&2; \
+		exit 1; \
+	fi; \
+	notes=$$(awk '/<change-notes>/{f=1;next} /<\/change-notes>/{exit} f' "$$xml"); \
+	if [ -z "$$(echo "$$notes" | tr -d '[:space:]')" ]; then \
+		echo "change-notes are empty" >&2; \
+		exit 1; \
+	fi; \
+	if echo "$$notes" | grep -q 'See the CHANGELOG for release notes.'; then \
+		version=$$($(GRADLE) properties -q 2>/dev/null | awk -F': ' '/^version:/ {print $$2}'); \
+		echo "no CHANGELOG.md section found for version $$version; change-notes fell back to a placeholder" >&2; \
+		exit 1; \
+	fi; \
+	echo "change-notes OK"
+
+## clean-change-notes: remove build output so the next run regenerates cleanly
+clean-change-notes:
+	$(GRADLE) clean

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,10 +46,92 @@ dependencies {
     }
 }
 
+// Build the plugin's <change-notes> from the current release's section in
+// CHANGELOG.md. Section selection matches the shared release workflow's
+// parse-release.sh (openfga/.github) so the GitHub release and the Marketplace
+// "What's New" render the same content. Falls back to a safe pointer if the
+// section is missing rather than failing the publish.
+fun changeNotesFromChangelog(rawVersion: String): String {
+    val changelog = file("CHANGELOG.md")
+    if (!changelog.exists()) return "See the CHANGELOG for release notes."
+
+    // Match the version delimited by non-version characters, as parse-release.sh does.
+    val escaped = Regex.escape(rawVersion)
+    val versionPattern = Regex("""(^|[^0-9A-Za-z.-])$escaped([^0-9A-Za-z.-]|$)""")
+
+    val section = mutableListOf<String>()
+    var found = false
+    for (line in changelog.readLines()) {
+        if (line.startsWith("## ")) {
+            if (found) break
+            if (versionPattern.containsMatchIn(line)) {
+                found = true
+                continue
+            }
+        }
+        if (found) section.add(line)
+    }
+
+    if (!found) return "See the CHANGELOG for release notes."
+
+    // Render inline markdown to HTML: `code` -> <code>, [text](url) -> <a>.
+    // Escape HTML-special chars first; markdown delimiters survive so the
+    // regexes still match. href values also escape " to avoid closing early.
+    fun renderInline(text: String): String {
+        var s = text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        s = Regex("""\[([^\]]+)]\(([^)]+)\)""").replace(s) { m ->
+            val href = m.groupValues[2].replace("\"", "&quot;")
+            """<a href="$href">${m.groupValues[1]}</a>"""
+        }
+        s = Regex("""`([^`]+)`""").replace(s) { m -> "<code>${m.groupValues[1]}</code>" }
+        return s
+    }
+
+    // ### Group -> <h2>, `* `/`- ` items -> <li>, everything else -> <p>.
+    val html = StringBuilder()
+    var listOpen = false
+    fun closeList() {
+        if (listOpen) {
+            html.append("</ul>\n")
+            listOpen = false
+        }
+    }
+    for (raw in section) {
+        val line = raw.trim()
+        when {
+            line.isEmpty() -> {}
+            line.startsWith("### ") -> {
+                closeList()
+                html.append("<h2>").append(line.removePrefix("### ").trim()).append("</h2>\n")
+            }
+            line.startsWith("* ") || line.startsWith("- ") -> {
+                if (!listOpen) {
+                    html.append("<ul>\n")
+                    listOpen = true
+                }
+                val item = line.removePrefix("* ").removePrefix("- ").trim()
+                html.append("<li>").append(renderInline(item)).append("</li>\n")
+            }
+            else -> {
+                closeList()
+                html.append("<p>").append(renderInline(line)).append("</p>\n")
+            }
+        }
+    }
+    closeList()
+
+    val rendered = html.toString().trim()
+    return rendered.ifEmpty { "See the CHANGELOG for release notes." }
+}
+
 // Configure IntelliJ Platform Gradle Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html
 intellijPlatform {
     pluginConfiguration {
+        changeNotes.set(provider { changeNotesFromChangelog(project.version.toString()) })
         ideaVersion {
             sinceBuild.set(providers.gradleProperty("plugin.sinceBuild"))
             untilBuild.set(providers.gradleProperty("plugin.untilBuild"))

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,12 +17,7 @@
     </ul>
     ]]></description>
 
-    <change-notes><![CDATA[
-    <h2>Added</h2>
-    <ul>
-        <li>Add support for 2026.1.* based IDEs</li>
-    </ul>
-    ]]></change-notes>
+    <!-- change-notes are generated at build time from CHANGELOG.md (see build.gradle.kts) -->
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
The <change-notes> block in plugin.xml was hand-maintained and drifted (v0.1.10 shipped v0.1.9's notes). Generate it at build time from the current release's section in CHANGELOG.md instead. Section selection matches the shared release workflow's parse-release.sh so the GitHub release and the Marketplace "What's New" render the same content, and inline markdown (code spans, links) is rendered to HTML. Falls back to a safe pointer if the section is missing so a bad edit never blocks a publish.

Adds a Makefile with verify-change-notes to inspect the generated block.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes are now generated automatically from the matching version section in `CHANGELOG.md`.
  * Changelog formatting, including headings, lists, links, and inline code, is preserved in the generated notes.

* **Bug Fixes**
  * Added safe fallback messaging when changelog content or the requested version section is unavailable.

* **Chores**
  * Added build commands to generate, verify, and clean generated release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->