### PR TITLE
fix: let relation references inherit the scheme's identifier color

### DIFF
--- a/src/main/java/dev/openfga/intellijplugin/OpenFGAColorSettingsPage.java
+++ b/src/main/java/dev/openfga/intellijplugin/OpenFGAColorSettingsPage.java
@@ -17,6 +17,7 @@ public class OpenFGAColorSettingsPage implements ColorSettingsPage {
         new AttributesDescriptor("Comment", OpenFGASyntaxHighlighter.COMMENT),
         new AttributesDescriptor("Type identifier", OpenFGASyntaxHighlighter.TYPE_IDENTIFIER),
         new AttributesDescriptor("Relation name", OpenFGASyntaxHighlighter.RELATION_NAME),
+        new AttributesDescriptor("Relation reference", OpenFGASyntaxHighlighter.RELATION_REFERENCE),
         new AttributesDescriptor("Schema version", OpenFGASyntaxHighlighter.SCHEMA_VERSIONS),
     };
 

--- a/src/main/resources/OpenFGA_Dark.xml
+++ b/src/main/resources/OpenFGA_Dark.xml
@@ -34,11 +34,6 @@
             <option name="FOREGROUND" value="20F1F5" />
         </value>
     </option>
-    <option name="OPENFGA_RELATION_REFERENCE">
-        <value>
-            <option name="FOREGROUND" value="FFFFFF" />
-        </value>
-    </option>
     <option name="OPENFGA_CONDITION_IDENTIFIER">
         <value>
             <option name="FOREGROUND" value="79ED83" />

--- a/src/main/resources/OpenFGA_Light.xml
+++ b/src/main/resources/OpenFGA_Light.xml
@@ -34,11 +34,6 @@
             <option name="FOREGROUND" value="0D8E91" />
         </value>
     </option>
-    <option name="OPENFGA_RELATION_REFERENCE">
-        <value>
-            <option name="FOREGROUND" value="1A1A1A" />
-        </value>
-    </option>
     <option name="OPENFGA_CONDITION_IDENTIFIER">
         <value>
             <option name="FOREGROUND" value="1A8C23" />


### PR DESCRIPTION
OPENFGA_RELATION_REFERENCE hard-coded a foreground (near-black in the light attributes file, white in dark). Schemes derived from Default/IntelliJ Light — including third-party dark schemes saved as copies of Default — inherited the near-black value, rendering relation references invisible on dark backgrounds. The explicit foreground also broke the declared fallback, so it couldn't be recovered via Language Defaults -> Identifiers.

Drop the explicit foreground so the key inherits
DefaultLanguageHighlighterColors.IDENTIFIER, which is always readable in the user's scheme. In the bundled light/dark schemes this matches the previous appearance.

Fixes #184

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable syntax color setting for relation references in the editor.

* **Bug Fixes**
  * Removed conflicting theme-specific relation reference color settings so the new customization applies consistently in light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->