### PR TITLE
fix: add reference attributes in color settings page

### DIFF
--- a/src/main/java/dev/openfga/intellijplugin/OpenFGAColorSettingsPage.java
+++ b/src/main/java/dev/openfga/intellijplugin/OpenFGAColorSettingsPage.java
@@ -24,6 +24,7 @@ public class OpenFGAColorSettingsPage implements ColorSettingsPage {
         new AttributesDescriptor("Condition reference", OpenFGASyntaxHighlighter.CONDITION_REFERENCE),
         new AttributesDescriptor("Condition param identifier", OpenFGASyntaxHighlighter.CONDITION_PARAM_IDENTIFIER),
         new AttributesDescriptor("Condition param type", OpenFGASyntaxHighlighter.CONDITION_PARAM_TYPE),
+        new AttributesDescriptor("Condition identifier", OpenFGASyntaxHighlighter.CONDITION_IDENTIFIER),
     };
 
     @Nullable

--- a/src/main/java/dev/openfga/intellijplugin/OpenFGAColorSettingsPage.java
+++ b/src/main/java/dev/openfga/intellijplugin/OpenFGAColorSettingsPage.java
@@ -18,6 +18,12 @@ public class OpenFGAColorSettingsPage implements ColorSettingsPage {
         new AttributesDescriptor("Type identifier", OpenFGASyntaxHighlighter.TYPE_IDENTIFIER),
         new AttributesDescriptor("Relation name", OpenFGASyntaxHighlighter.RELATION_NAME),
         new AttributesDescriptor("Schema version", OpenFGASyntaxHighlighter.SCHEMA_VERSIONS),
+        new AttributesDescriptor("Relation reference", OpenFGASyntaxHighlighter.RELATION_REFERENCE),
+        new AttributesDescriptor("Module name", OpenFGASyntaxHighlighter.MODULE_NAME),
+        new AttributesDescriptor("Type reference", OpenFGASyntaxHighlighter.TYPE_REFERENCE),
+        new AttributesDescriptor("Condition reference", OpenFGASyntaxHighlighter.CONDITION_REFERENCE),
+        new AttributesDescriptor("Condition param identifier", OpenFGASyntaxHighlighter.CONDITION_PARAM_IDENTIFIER),
+        new AttributesDescriptor("Condition param type", OpenFGASyntaxHighlighter.CONDITION_PARAM_TYPE),
     };
 
     @Nullable


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
The current color settings page doesn't expose reference attributes.  
#### How is it being solved?
Add the reference attributes in the DESCRIPTORS array
#### What changes are made to solve it?
Add related attributes in DESCRIPTORS array in OpenFGAColorSettingsPage.java
## References

closes [issue#183](https://github.com/openfga/intellij-plugin/issues/183)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added syntax highlighting options for relation references, module names, type references, condition references, and condition parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->